### PR TITLE
Corrected ResultSet bug and final delimiter bug.

### DIFF
--- a/ScriptRunner.java
+++ b/ScriptRunner.java
@@ -175,13 +175,13 @@ public class ScriptRunner {
                     if (hasResults && rs != null) {
                         ResultSetMetaData md = rs.getMetaData();
                         int cols = md.getColumnCount();
-                        for (int i = 0; i < cols; i++) {
+                        for (int i = 1; i <= cols; i++) {
                             String name = md.getColumnLabel(i);
                             print(name + "\t");
                         }
                         println("");
                         while (rs.next()) {
-                            for (int i = 0; i < cols; i++) {
+                            for (int i = 1; i <= cols; i++) {
                                 String value = rs.getString(i);
                                 print(value + "\t");
                             }

--- a/ScriptRunner.java
+++ b/ScriptRunner.java
@@ -151,54 +151,15 @@ public class ScriptRunner {
                     command.append(line.substring(0, line
                             .lastIndexOf(getDelimiter())));
                     command.append(" ");
-                    Statement statement = conn.createStatement();
-
-                    println(command);
-
-                    boolean hasResults = false;
-                    try {
-                        hasResults = statement.execute(command.toString());
-                    } catch (SQLException e) {
-                        final String errText = String.format("Error executing '%s' (line %d): %s", command, lineReader.getLineNumber(), e.getMessage());
-                        if (stopOnError) {
-                            throw new SQLException(errText, e);
-                        } else {
-                            println(errText);
-                        }
-                    }
-
-                    if (autoCommit && !conn.getAutoCommit()) {
-                        conn.commit();
-                    }
-
-                    ResultSet rs = statement.getResultSet();
-                    if (hasResults && rs != null) {
-                        ResultSetMetaData md = rs.getMetaData();
-                        int cols = md.getColumnCount();
-                        for (int i = 1; i <= cols; i++) {
-                            String name = md.getColumnLabel(i);
-                            print(name + "\t");
-                        }
-                        println("");
-                        while (rs.next()) {
-                            for (int i = 1; i <= cols; i++) {
-                                String value = rs.getString(i);
-                                print(value + "\t");
-                            }
-                            println("");
-                        }
-                    }
-
+                    this.execCommand(conn, command, lineReader);
                     command = null;
-                    try {
-                        statement.close();
-                    } catch (Exception e) {
-                        // Ignore to workaround a bug in Jakarta DBCP
-                    }
                 } else {
                     command.append(line);
                     command.append("\n");
                 }
+            }
+            if (command != null) {
+            	this.execCommand(conn, command, lineReader);
             }
             if (!autoCommit) {
                 conn.commit();
@@ -210,6 +171,53 @@ public class ScriptRunner {
             flush();
         }
     }
+
+	private void execCommand(Connection conn, StringBuffer command,
+			LineNumberReader lineReader) throws SQLException {
+		Statement statement = conn.createStatement();
+
+		println(command);
+
+		boolean hasResults = false;
+		try {
+		    hasResults = statement.execute(command.toString());
+		} catch (SQLException e) {
+		    final String errText = String.format("Error executing '%s' (line %d): %s", command, lineReader.getLineNumber(), e.getMessage());
+		    if (stopOnError) {
+		        throw new SQLException(errText, e);
+		    } else {
+		        println(errText);
+		    }
+		}
+
+		if (autoCommit && !conn.getAutoCommit()) {
+		    conn.commit();
+		}
+
+		ResultSet rs = statement.getResultSet();
+		if (hasResults && rs != null) {
+		    ResultSetMetaData md = rs.getMetaData();
+		    int cols = md.getColumnCount();
+		    for (int i = 1; i <= cols; i++) {
+		        String name = md.getColumnLabel(i);
+		        print(name + "\t");
+		    }
+		    println("");
+		    while (rs.next()) {
+		        for (int i = 1; i <= cols; i++) {
+		            String value = rs.getString(i);
+		            print(value + "\t");
+		        }
+		        println("");
+		    }
+		}
+
+		try {
+		    statement.close();
+		} catch (Exception e) {
+		    // Ignore to workaround a bug in Jakarta DBCP
+		}
+	}
 
     private String getDelimiter() {
         return delimiter;


### PR DESCRIPTION
The ResultSet logging was causing "org.postgresql.util.PSQLException: The column index is out of range: 0, number of columns: XXX."
If the last statement on a script failed to have a delimiter, it was being silently ignored.
